### PR TITLE
Add feature data taxonomy

### DIFF
--- a/qtp_diversity/__init__.py
+++ b/qtp_diversity/__init__.py
@@ -22,7 +22,10 @@ artifact_types = [
                       [('plain_text', True), ('qza', False)]),
     QiitaArtifactType('alpha_vector', 'Alpha Diversity per sample results',
                       False, False, False, [('plain_text', True),
-                                            ('qza', False)])]
+                                            ('qza', False)]),
+    QiitaArtifactType('FeatureData[Taxonomy]', 'Taxonomy assignments', False,
+                      False, False, [('plain_text', True), ('qza', False)])
+]
 
 # Initialize the plugin
 plugin = QiitaTypePlugin('Diversity types', '0.1.1',

--- a/qtp_diversity/summary.py
+++ b/qtp_diversity/summary.py
@@ -139,7 +139,7 @@ def _generate_alpha_vector_summary(files, metadata, out_dir):
     return html_fp, html_dir
 
 
-def _generate_feature_data_taxonomy(files, out_dir):
+def _generate_feature_data_taxonomy(files, metadata, out_dir):
     # Magic number [0] -> there is only one plain text file and it is the
     # feature data taxonomy
     fdt_fp = files['plain_text'][0]

--- a/qtp_diversity/summary.py
+++ b/qtp_diversity/summary.py
@@ -108,7 +108,7 @@ def _generate_alpha_vector_summary(files, metadata, out_dir):
     std_out, std_err, return_value = system_call(cmd)
     if return_value != 0:
         error_msg = "Error converting the alpha vectors file to Q2 artifact"
-        return False, None, error_msg
+        raise RuntimeError(error_msg)
 
     # Generate the metadata file
     metadata = pd.DataFrame.from_dict(metadata, orient='index')
@@ -139,10 +139,53 @@ def _generate_alpha_vector_summary(files, metadata, out_dir):
     return html_fp, html_dir
 
 
+def _generate_feature_data_taxonomy(files, out_dir):
+    # Magic number [0] -> there is only one plain text file and it is the
+    # feature data taxonomy
+    fdt_fp = files['plain_text'][0]
+
+    if 'qza' not in files:
+        fdt_qza = join(out_dir, 'taxonomy.qza')
+        # Get the SampleData[AlphaDiversity] qiime2 artifact
+        cmd = ('qiime tools import --input-path %s --output-path %s '
+               '--type "FeatureData[Taxonomy]"'
+               % (fdt_fp, fdt_qza))
+        std_out, std_err, return_value = system_call(cmd)
+        if return_value != 0:
+            error_msg = ("Error converting the taxonomy file to "
+                         "Q2 artifact")
+            raise RuntimeError(error_msg)
+    else:
+        fdt_qza = files['qza'][0]
+
+    # Tabulate taxonomies
+    fdt_qzv = join(out_dir, 'taxonomy.qzv')
+    cmd = ('qiime metadata tabulate --m-input-file %s --o-visualization %s'
+           % (fdt_qza, fdt_qzv))
+    std_out, std_err, return_value = system_call(cmd)
+    if return_value != 0:
+        error_msg = "Error tabulating Q2 artifact"
+        raise RuntimeError(error_msg)
+
+    # Extract the Q2 visualization to use it as html_summary
+    q2vis = Visualization.load(fdt_qzv)
+    html_dir = join(out_dir, 'support_files')
+    html_fp = join(out_dir, 'index.html')
+
+    q2vis.export_data(html_dir)
+    index_paths = q2vis.get_index_paths()
+    index_name = basename(index_paths['html'])
+    with open(html_fp, 'w') as f:
+        f.write(Q2_INDEX % index_name)
+
+    return html_fp, html_dir
+
+
 HTML_SUMMARIZERS = {
     'distance_matrix': _generate_distance_matrix_summary,
     'ordination_results': _generate_ordination_results_summary,
-    'alpha_vector': _generate_alpha_vector_summary
+    'alpha_vector': _generate_alpha_vector_summary,
+    'FeatureData[Taxonomy]': _generate_feature_data_taxonomy
 }
 
 
@@ -189,8 +232,11 @@ def generate_html_summary(qclient, job_id, parameters, out_dir):
     else:
         return (False, None, "Missing metadata information")
 
-    html_fp, html_dir = HTML_SUMMARIZERS[atype](artifact_info['files'],
-                                                metadata, out_dir)
+    try:
+        html_fp, html_dir = HTML_SUMMARIZERS[atype](
+            artifact_info['files'], metadata, out_dir)
+    except Exception as e:
+        return False, None, str(e)
 
     if html_dir:
         patch_val = dumps({'html': html_fp, 'dir': html_dir})

--- a/qtp_diversity/tests/test_summary.py
+++ b/qtp_diversity/tests/test_summary.py
@@ -233,7 +233,7 @@ class SummaryTests(PluginTestCase):
             f.write("TACGTAGGG\tk__Bacteria;p__Firmicutes;c__Clostridia\t"
                     "0.9999999\n")
         obs_fp, obs_dp = _generate_feature_data_taxonomy(
-            {'plain_text': [taxonomy_fp]}, self.out_dir)
+            {'plain_text': [taxonomy_fp]}, None, self.out_dir)
         self.assertEqual(obs_fp, join(self.out_dir, 'index.html'))
         self.assertEqual(obs_dp, join(self.out_dir, 'support_files'))
         self.assertTrue(exists(obs_fp))
@@ -255,7 +255,7 @@ class SummaryTests(PluginTestCase):
                     "0.9999999\n")
         with self.assertRaises(RuntimeError):
             obs_fp, obs_dp = _generate_feature_data_taxonomy(
-                {'plain_text': [taxonomy_fp]}, self.out_dir)
+                {'plain_text': [taxonomy_fp]}, None, self.out_dir)
 
 
 EXP_HTML_REGEXP = """<b>Number of samples:</b> 3</br>

--- a/qtp_diversity/tests/test_validate.py
+++ b/qtp_diversity/tests/test_validate.py
@@ -274,7 +274,7 @@ class ValidateTests(PluginTestCase):
 
         # Test success
         obs_success, obs_ainfo, obs_error = _validate_feature_data_taxonomy(
-            {'plain_text': [taxonomy_fp]}, self.out_dir)
+            {'plain_text': [taxonomy_fp]}, None, self.out_dir)
         self.assertEqual(obs_error, "")
         self.assertTrue(obs_success)
         exp_ainfo = [ArtifactInfo(None, "FeatureData[Taxonomy]",
@@ -291,7 +291,7 @@ class ValidateTests(PluginTestCase):
             f.write("TACGTAGGG\tk__Bacteria;p__Firmicutes;c__Clostridia\t"
                     "0.9999999\n")
         obs_success, obs_ainfo, obs_error = _validate_feature_data_taxonomy(
-            {'plain_text': [taxonomy_fp]}, self.out_dir)
+            {'plain_text': [taxonomy_fp]}, None, self.out_dir)
         self.assertIn("The file header seems wrong", obs_error)
         self.assertFalse(obs_success)
         self.assertIsNone(obs_ainfo)

--- a/qtp_diversity/tests/test_validate.py
+++ b/qtp_diversity/tests/test_validate.py
@@ -23,7 +23,7 @@ import numpy as np
 from qtp_diversity import plugin
 from qtp_diversity.validate import (
     _validate_distance_matrix, _validate_ordination_results,
-    _validate_alpha_vector, validate)
+    _validate_alpha_vector, _validate_feature_data_taxonomy, validate)
 
 
 class ValidateTests(PluginTestCase):
@@ -198,7 +198,8 @@ class ValidateTests(PluginTestCase):
         self.assertIsNone(obs_ainfo)
         self.assertEqual(
             obs_error, "Unknown artifact type NotAType. Supported types: "
-                       "alpha_vector, distance_matrix, ordination_results")
+                       "FeatureData[Taxonomy], alpha_vector, distance_matrix, "
+                       "ordination_results")
 
         # Test missing metadata error - to be fair, I don't know how this error
         # can happen in the live system, but better be safe than sorry
@@ -259,6 +260,41 @@ class ValidateTests(PluginTestCase):
                       (sf_fp, 'html_summary_dir')])]
         self.assertEqual(obs_ainfo, exp_ainfo)
         self.assertEqual(obs_error, "")
+
+    def test_validate_FeatureData_Taxonomy(self):
+        # Create the feature data
+        fd, taxonomy_fp = mkstemp(suffix='.txt', dir=self.out_dir)
+        close(fd)
+        with open(taxonomy_fp, 'w') as f:
+            f.write("Feature ID\tTaxonomy\tConfidence\n")
+            f.write("TACGGAGGA\tk__Bacteria;p__Bacteroidetes;c__Bacteroidia\t"
+                    "0.9998743\n")
+            f.write("TACGTAGGG\tk__Bacteria;p__Firmicutes;c__Clostridia\t"
+                    "0.9999999\n")
+
+        # Test success
+        obs_success, obs_ainfo, obs_error = _validate_feature_data_taxonomy(
+            {'plain_text': [taxonomy_fp]}, self.out_dir)
+        self.assertEqual(obs_error, "")
+        self.assertTrue(obs_success)
+        exp_ainfo = [ArtifactInfo(None, "FeatureData[Taxonomy]",
+                     [(taxonomy_fp, 'plain_text')])]
+        self.assertEqual(obs_ainfo, exp_ainfo)
+
+        # Test failure wrong format
+        fd, taxonomy_fp = mkstemp(suffix='.txt', dir=self.out_dir)
+        close(fd)
+        with open(taxonomy_fp, 'w') as f:
+            f.write("Feature ID\tIt's gonna fail!\tConfidence\n")
+            f.write("TACGGAGGA\tk__Bacteria;p__Bacteroidetes;c__Bacteroidia\t"
+                    "0.9998743\n")
+            f.write("TACGTAGGG\tk__Bacteria;p__Firmicutes;c__Clostridia\t"
+                    "0.9999999\n")
+        obs_success, obs_ainfo, obs_error = _validate_feature_data_taxonomy(
+            {'plain_text': [taxonomy_fp]}, self.out_dir)
+        self.assertIn("The file header seems wrong", obs_error)
+        self.assertFalse(obs_success)
+        self.assertIsNone(obs_ainfo)
 
 
 if __name__ == '__main__':

--- a/qtp_diversity/validate.py
+++ b/qtp_diversity/validate.py
@@ -96,7 +96,7 @@ def _validate_alpha_vector(files, metadata, out_dir):
     return True, [ArtifactInfo(None, 'alpha_vector', filepaths)], ""
 
 
-def _validate_feature_data_taxonomy(files, out_dir):
+def _validate_feature_data_taxonomy(files, metadata, out_dir):
     # Magic number [0] -> there is only one plain text file, which is the
     # ordination results
     fdt = files['plain_text'][0]

--- a/qtp_diversity/validate.py
+++ b/qtp_diversity/validate.py
@@ -96,6 +96,27 @@ def _validate_alpha_vector(files, metadata, out_dir):
     return True, [ArtifactInfo(None, 'alpha_vector', filepaths)], ""
 
 
+def _validate_feature_data_taxonomy(files, out_dir):
+    # Magic number [0] -> there is only one plain text file, which is the
+    # ordination results
+    fdt = files['plain_text'][0]
+    fdt_qza = None
+    if 'qza' in files:
+        fdt_qza = files['qza'][0]
+
+    # basic header check to verify that it looks like a taxonomy file
+    with open(fdt) as f:
+        line = f.readline()
+        if 'Tax' not in line or 'ID' not in line:
+            return (False, None, 'The file header seems wrong "%s"' % line)
+
+    filepaths = [(fdt, 'plain_text')]
+    if fdt_qza is not None:
+        filepaths.append((fdt_qza, 'qza'))
+
+    return True, [ArtifactInfo(None, 'FeatureData[Taxonomy]', filepaths)], ""
+
+
 def validate(qclient, job_id, parameters, out_dir):
     """Validates and fix a new artifact
 
@@ -124,7 +145,8 @@ def validate(qclient, job_id, parameters, out_dir):
 
     validators = {'distance_matrix': _validate_distance_matrix,
                   'ordination_results': _validate_ordination_results,
-                  'alpha_vector': _validate_alpha_vector}
+                  'alpha_vector': _validate_alpha_vector,
+                  'FeatureData[Taxonomy]': _validate_feature_data_taxonomy}
 
     # Check if the validate is of a type that we support
     if a_type not in validators:


### PR DESCRIPTION
Also fixing/adding `raise RuntimeError(error_msg)` within the `_generate_*_summary` as `return False, None, error_msg` will yield a non-descriptive error.
       